### PR TITLE
Fix warning: Default argument is mutable

### DIFF
--- a/tmrl/envs.py
+++ b/tmrl/envs.py
@@ -12,7 +12,7 @@ __docformat__ = "google"
 
 
 class GenericGymEnv(gymnasium.Wrapper):
-    def __init__(self, id: str = "Pendulum-v0", gym_kwargs={}, obs_scale: float = 0., to_float32=False):
+    def __init__(self, id: str = "Pendulum-v0", gym_kwargs=None, obs_scale: float = 0., to_float32=False):
         """
         Use this wrapper when using the framework with arbitrary environments.
 
@@ -22,6 +22,8 @@ class GenericGymEnv(gymnasium.Wrapper):
             obs_scale (float): change this if wanting to rescale actions by a scalar
             to_float32 (bool): set this to True if wanting observations to be converted to numpy.float32
         """
+        if gym_kwargs is None:
+            gym_kwargs = {}
         env = gymnasium.make(id, **gym_kwargs, disable_env_checker=True)
         if obs_scale:
             env = AffineObservationWrapper(env, 0, obs_scale)


### PR DESCRIPTION
Explanation of the warning in IntelliJ:

Reports a problem when a mutable value as a list or dictionary is detected in a default value for an argument. Default argument values are evaluated only once at function definition time, which means that modifying the default value of the argument will affect all subsequent calls of that function. Example:
```
def func(s, cache={}):
     cache[s] = None
```
When the quick-fix is applied, the code changes to:
```
def func(s, cache=None):
     if cache is None:
              cache = {}
     cache[s] = None
``